### PR TITLE
Unified all error types into a single one, located in error.rs. Token…

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,55 @@
+use std::fmt;
+use std::num;
+use std::error::Error as StdError;
+
+use error::Error::*;
+
+pub type Result<T> = ::std::result::Result<T, Error>;
+
+#[derive(Debug, Clone, PartialEq)]
+/// The error types of the interpreter.
+pub enum Error {
+    InfiniteString,
+    StringEOL,
+    LargeInt,
+    BadRealLiteral,
+    Illegal(char),
+    UnknownEscape(char),
+    ParseIntError(num::ParseIntError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Illegal(c) => write!(f, "{} {}", self.description(), c),
+            UnknownEscape(c) => {
+                write!(f,
+                       "{} {}",
+                       self.description(),
+                       c.escape_default().collect::<String>())
+            }
+            ParseIntError(ref e) => fmt::Display::fmt(e, f),
+            _ => f.write_str(self.description()),
+        }
+    }
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        match *self {
+            InfiniteString => "infinite string literal",
+            StringEOL => "found newline in string literal",
+            LargeInt => "int literal too big",
+            BadRealLiteral => "could not parse real literal",
+            Illegal(_) => "found illegal character",
+            UnknownEscape(_) => "found unknow escape code",
+            ParseIntError(ref e) => e.description(),
+        }
+    }
+}
+
+impl From<num::ParseIntError> for Error {
+    fn from(err: num::ParseIntError) -> Self {
+        ParseIntError(err)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@ pub mod lexer;
 pub mod tokens;
 pub mod parser;
 pub mod real;
+pub mod error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 extern crate interpreter;
 
 use interpreter::lexer;
-use interpreter::real;
 
 use std::io::Read;
 use std::fs::File;

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,11 +1,7 @@
 use std::fmt;
-use std::error::Error as StdError;
 
 use tokens::Token::*;
-use tokens::LexerError::*;
 use real::Real;
-
-pub type LexerResult = Result<Token, LexerError>;
 
 /// Represents a valid token returned by `Lexer::get_token`
 #[derive(Debug, Clone, PartialEq)]
@@ -135,47 +131,6 @@ impl fmt::Display for Token {
             Identity(ref i) => write!(f, "Identity: \"{}\"", i),
             _ => write!(f, "{:?}", self),
         }
-    }
-}
-
-/// Represents a error encountered during the lexical analysis.
-#[derive(Debug, Clone, PartialEq)]
-pub enum LexerError {
-    NonTerminatingString,
-    StringEOL,
-    Illegal(char),
-    UnknownEscape(char),
-    IntLiteralTooLarge,
-    RealParseError,
-}
-
-impl fmt::Display for LexerError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Illegal(c) => write!(f, "{} {}", self.description(), c),
-            UnknownEscape(c) => {
-                let s: String = c.escape_default().collect();
-                write!(f, "{} {}", self.description(), s)
-            }
-            _ => f.write_str(self.description()),
-        }
-    }
-}
-
-impl StdError for LexerError {
-    fn description(&self) -> &str {
-        match *self {
-            NonTerminatingString => "string never ends",
-            StringEOL => "found newline in string literal",
-            Illegal(_) => "found illegal character",
-            UnknownEscape(_) => "found unknow escape code",
-            IntLiteralTooLarge => "int literal too large",
-            RealParseError => "could not parse real literal",
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        None
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,8 +1,9 @@
 extern crate interpreter;
 
 use interpreter::lexer;
-use interpreter::tokens::{Token, LexerError};
+use interpreter::tokens::Token;
 use interpreter::real::Real;
+use interpreter::error::Error;
 
 #[test]
 #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -25,7 +26,7 @@ fn next_token_test() {
 #[cfg_attr(rustfmt, rustfmt_skip)]
 fn test_neverending_string() {
     let mut lexer = lexer::Lexer::new("\"This string never ends");
-    let tokens = vec![Err(LexerError::NonTerminatingString), Ok(Token::EndOfFile)];
+    let tokens = vec![Err(Error::InfiniteString), Ok(Token::EndOfFile)];
 
     for t in &tokens {
         let token = lexer.next_token();
@@ -68,19 +69,19 @@ fn test_string_escape() {
 #[cfg_attr(rustfmt, rustfmt_skip)]
 fn test_string_illegal_newline() {
     let mut lexer = lexer::Lexer::new("\"\n\"\\");
-    assert_eq!(Err(LexerError::StringEOL), lexer.next_token());
-    assert_eq!(Err(LexerError::NonTerminatingString), lexer.next_token());
+    assert_eq!(Err(Error::StringEOL), lexer.next_token());
+    assert_eq!(Err(Error::InfiniteString), lexer.next_token());
 }
 
 #[test]
 #[cfg_attr(rustfmt, rustfmt_skip)]
 fn test_error_tokens() {
     let mut lexer = lexer::Lexer::new("$%`^~");
-    let tokens = vec![Err(LexerError::Illegal('$')),
-                      Err(LexerError::Illegal('%')),
-                      Err(LexerError::Illegal('`')),
-                      Err(LexerError::Illegal('^')),
-                      Err(LexerError::Illegal('~')),
+    let tokens = vec![Err(Error::Illegal('$')),
+                      Err(Error::Illegal('%')),
+                      Err(Error::Illegal('`')),
+                      Err(Error::Illegal('^')),
+                      Err(Error::Illegal('~')),
                       Ok(Token::EndOfFile)];
     for t in &tokens {
         let token = lexer.next_token();
@@ -89,17 +90,17 @@ fn test_error_tokens() {
 }
 
 #[test]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[cfg_attr(rustfmt, rustfmp)]
 fn test_error_messages() {
     let mut lexer = lexer::Lexer::new("\"\n\
     💡 \
     \"\\x \
     \"");
-    let tokens = vec![Err(LexerError::StringEOL),
-                      Err(LexerError::Illegal('💡')),
-                      Err(LexerError::UnknownEscape('x')),
+    let tokens = vec![Err(Error::StringEOL),
+                      Err(Error::Illegal('💡')),
+                      Err(Error::UnknownEscape('x')),
                       Ok(Token::Identity("x".to_owned())), // The lexer does not consume the illegal escape
-                      Err(LexerError::NonTerminatingString),
+                      Err(Error::InfiniteString),
                       Ok(Token::EndOfFile)];
     for t in &tokens {
         let token = lexer.next_token();


### PR DESCRIPTION
… and Reak no longer have their own error type, cleaned up error handling real.rs and lexer.rs